### PR TITLE
Bump golangci-lint version

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -25,13 +25,11 @@ linters-settings:
     min-complexity: 30
   goimports:
     local-prefixes: github.com/Mellanox/ib-sriov-cni
-  golint:
-    min-confidence: 0
   gomnd:
     settings:
       mnd:
         # don't include the "operation" and "assign"
-        checks: argument,case,condition,return
+        checks: [argument,case,condition,return]
   govet:
     check-shadowing: true
     settings:
@@ -55,11 +53,11 @@ linters:
   disable-all: true
   enable:
     - bodyclose
-    - deadcode
     - depguard
     - dogsled
     - dupl
     - errcheck
+    - exportloopref
     - funlen
     - gochecknoinits
     - goconst
@@ -67,7 +65,6 @@ linters:
     - gocognit
     - gofmt
     - goimports
-    - golint
     - gomnd
     - goprintffuncname
     - gosec
@@ -78,16 +75,14 @@ linters:
     - misspell
     - nakedret
     - prealloc
+    - revive
     - rowserrcheck
-    - scopelint
     - staticcheck
-    - structcheck
     - stylecheck
     - typecheck
     - unconvert
     - unparam
     - unused
-    - varcheck
     - whitespace
 
 issues:

--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,7 @@ GOLANGCI_LINT = $(GOBIN)/golangci-lint
 # golangci-lint version should be updated periodically
 # we keep it fixed to avoid it from unexpectedly failing on the project
 # in case of a version bump
-GOLANGCI_LINT_VER = v1.46.2
+GOLANGCI_LINT_VER = v1.51.2
 TIMEOUT = 15
 Q = $(if $(filter 1,$V),,@)
 


### PR DESCRIPTION
typecheck seems to not play nice with go 1.20[1].
with the current version of golangci-lint we are using.

bump to latest release.

[1] https://github.com/golangci/golangci-lint/issues/3420