### PR TITLE
Optionally avoid sleeping in entrypoint.sh

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ COMMIT?=`git rev-parse --verify HEAD`
 LDFLAGS="-X main.version=$(VERSION) -X main.commit=$(COMMIT) -X main.date=$(DATE)"
 
 # Docker
-IMAGE_BUILDER?=@docker
+IMAGE_BUILDER?=docker
 IMAGEDIR=$(BASE)/images
 DOCKERFILE?=$(CURDIR)/Dockerfile
 TAG?=k8snetworkplumbingwg/ib-sriov-cni
@@ -126,12 +126,15 @@ shellcheck: $(BASE) $(SHELLCHECK_TOOL); $(info  running shellcheck...) @ ## Run 
 # Container image
 .PHONY: image
 image: | $(BASE) ; $(info Building Docker image...)  ## Build conatiner image
-	$(IMAGE_BUILDER) build -t $(TAG) -f $(DOCKERFILE)  $(CURDIR) $(IMAGE_BUILD_OPTS)
+	@$(IMAGE_BUILDER) build -t $(TAG) -f $(DOCKERFILE)  $(CURDIR) $(IMAGE_BUILD_OPTS)
 
 # Dependency management
 .PHONY: deps-update
 deps-update: ; $(info  updating dependencies...)
 	go mod tidy && go mod vendor
+
+test-image: image
+	$Q $(BASE)/images/image_test.sh $(IMAGE_BUILDER) $(TAG)
 
 # Misc
 

--- a/images/entrypoint.sh
+++ b/images/entrypoint.sh
@@ -6,6 +6,7 @@ set -e
 # Set known directories.
 CNI_BIN_DIR="/host/opt/cni/bin"
 IB_SRIOV_CNI_BIN_FILE="/usr/bin/ib-sriov"
+NO_SLEEP=0
 
 # Give help text for parameters.
 usage()
@@ -18,6 +19,7 @@ usage()
     printf "\t-h --help\n"
     printf "\t--cni-bin-dir=%s\n" "$CNI_BIN_DIR"
     printf "\t--ib-sriov-cni-bin-file=%s\n" "$IB_SRIOV_CNI_BIN_FILE"
+    printf "\t--no-sleep\n"
 }
 
 # Parse parameters given as arguments to this script.
@@ -34,6 +36,9 @@ while [ "$1" != "" ]; do
             ;;
         --ib-sriov-cni-bin-file)
             IB_SRIOV_CNI_BIN_FILE=$VALUE
+            ;;
+        --no-sleep)
+            NO_SLEEP=1
             ;;
         *)
             /bin/echo "ERROR: unknown parameter \"$PARAM\""
@@ -56,6 +61,10 @@ done
 
 # Copy file into proper place.
 cp -f "$IB_SRIOV_CNI_BIN_FILE" "$CNI_BIN_DIR"
+
+if [ $NO_SLEEP -eq 1 ]; then
+  exit 0
+fi
 
 echo "Entering sleep... (success)"
 trap : TERM INT

--- a/images/image_test.sh
+++ b/images/image_test.sh
@@ -1,0 +1,22 @@
+#!/bin/sh
+
+set -x
+
+OCI_RUNTIME=$1
+IMAGE_UNDER_TEST=$2
+
+OUTPUT_DIR=$(mktemp -d)
+
+"${OCI_RUNTIME}" run -v "${OUTPUT_DIR}:/out" "${IMAGE_UNDER_TEST}" --cni-bin-dir=/out --no-sleep
+
+if [ ! -e "${OUTPUT_DIR}/ib-sriov" ]; then
+    echo "Output file ${OUTPUT_DIR}/ib-sriov not found"
+    exit 1
+fi
+
+if [ ! -s "${OUTPUT_DIR}/ib-sriov" ]; then
+    echo "Output file ${OUTPUT_DIR}/ib-sriov is empty"
+    exit 1
+fi
+
+exit 0


### PR DESCRIPTION
Container image might be used as `initcontainers` in kubernetes Pods. In such scenarios, it's important for the image entrypoint to exits once the copy logic is completed. Otherwise, the pod would stuck in a `PodInitializing` phase.

Add Makefile rule `image-test` to check the integrity of the entrypoint.sh script.

https://kubernetes.io/docs/concepts/workloads/pods/init-containers/

refs:

- https://github.com/k8snetworkplumbingwg/sriov-network-operator/pull/581