### PR TITLE
Remove `linux-headers` apk from Dockerfile 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ COPY . /usr/src/ib-sriov-cni
 ENV HTTP_PROXY $http_proxy
 ENV HTTPS_PROXY $https_proxy
 
-RUN apk add --no-cache --virtual build-dependencies build-base=~0.5 linux-headers=~6.3
+RUN apk add --no-cache --virtual build-dependencies build-base=~0.5
 WORKDIR /usr/src/ib-sriov-cni
 RUN make clean && \
     make build


### PR DESCRIPTION
Referring an exact version of the linux-headers package might break image building process, with errors like:

```
#11 0.185 fetch https://dl-cdn.alpinelinux.org/alpine/v3.19/community/x86_64/APKINDEX.tar.gz
#11 0.459 ERROR: unable to select packages:
#11 0.461   linux-headers-6.5-r0:
#11 0.461     breaks: build-dependencies-20240212.104211[linux-headers~6.3]
#11 0.461   build-dependencies-20240212.104211:
#11 0.461     masked in: cache
#11 0.461     satisfies: world[build-dependencies=20240212.104211]
#11 ERROR: process "/bin/sh -c apk add --no-cache --virtual build-dependencies build-base=~0.5 linux-headers=~6.3" did not complete successfully: exit code: 2
```

Comes from:
- https://github.com/k8snetworkplumbingwg/ib-sriov-cni/pull/80

@almaslennikov I'm not sure why we introduced the `linux-headers` package. I can remove it if it's not really needed. Please, take a look


:exclamation:  **Note**: no new image is currently published for this repository due to this error. (see [action log](https://github.com/k8snetworkplumbingwg/ib-sriov-cni/actions/runs/7870529836/job/21471893507))