### PR TITLE
update git ignore to not exclude internal build folders

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,5 +3,5 @@
 *.cover
 
 # Folders
-build/
-bin/
+/build/
+/bin/


### PR DESCRIPTION
when using vendor there is a file in git that gets ignored and it should not

```
git status --porcelain --ignored
!! bin/
!! build/
!! vendor/github.com/onsi/ginkgo/v2/ginkgo/build/
```