### PR TITLE
VFIO device support

### DIFF
--- a/cmd/ib-sriov-cni/main.go
+++ b/cmd/ib-sriov-cni/main.go
@@ -95,6 +95,24 @@ func unlockCNIExecution(lock *flock.Flock) {
 	_ = lock.Unlock()
 }
 
+func handleVfioPciDetection(netConf *localtypes.NetConf) error {
+	if netConf.DeviceID == "" {
+		return nil
+	}
+
+	// If vfioPciMode is explicitly set to true, use it; otherwise auto-detect
+	if !netConf.VfioPciMode {
+		isVfioPci, err := utils.IsVfioPciDevice(netConf.DeviceID)
+		if err != nil {
+			return fmt.Errorf("failed to check vfio-pci driver binding for device %s: %v", netConf.DeviceID, err)
+		}
+		if isVfioPci {
+			netConf.VfioPciMode = true
+		}
+	}
+	return nil
+}
+
 // Get network config, updated with GUID, device info and network namespace.
 func getNetConfNetns(args *skel.CmdArgs) (*localtypes.NetConf, ns.NetNS, error) {
 	netConf, err := config.LoadConf(args.StdinData)
@@ -114,6 +132,21 @@ func getNetConfNetns(args *skel.CmdArgs) (*localtypes.NetConf, ns.NetNS, error) 
 	if netConf.IBKubernetesEnabled && netConf.GUID == "" {
 		return nil, nil, fmt.Errorf(
 			"infiniband SRIOV-CNI failed, Unexpected error. GUID must be provided by ib-kubernetes")
+	}
+
+	// Handle vfio-pci detection
+	if err := handleVfioPciDetection(netConf); err != nil {
+		return nil, nil, err
+	}
+
+	// If vfioPciMode is true (either set manually or auto-detected), skip SR-IOV setup
+	if netConf.VfioPciMode {
+		// Skip normal SR-IOV setup for vfio-pci devices, just get netns and return
+		netns, err := ns.GetNS(args.Netns)
+		if err != nil {
+			return nil, nil, fmt.Errorf("failed to open netns %q: %v", netns, err)
+		}
+		return netConf, netns, nil
 	}
 
 	if netConf.RdmaIso {
@@ -215,12 +248,97 @@ func runIPAMPlugin(stdinData []byte, netConf *localtypes.NetConf) (_ *current.Re
 	return newResult, nil
 }
 
+// handleVfioPciMode handles VFIO PCI devices with VF GUID setting if needed
+func handleVfioPciMode(args *skel.CmdArgs, netConf *localtypes.NetConf, netns ns.NetNS) error {
+	// Check if the device is a VF (Virtual Function) or PF (Physical Function)
+	isVF, err := utils.IsVirtualFunction(netConf.DeviceID)
+	if err != nil {
+		return fmt.Errorf("failed to determine if device %s is VF or PF: %v", netConf.DeviceID, err)
+	}
+
+	// Only handle GUID setting for VF devices, keep previous code path for PF devices
+	if isVF && netConf.GUID != "" {
+		// Load device info needed for GUID setting (VFIO VF version - no network interface)
+		err = config.LoadDeviceInfoVfioVF(netConf)
+		if err != nil {
+			return fmt.Errorf("failed to get device specific information for vfio-pci VF device: %v", err)
+		}
+
+		sm := sriov.NewSriovManager()
+		if err := sm.ApplyVFConfig(netConf); err != nil {
+			return fmt.Errorf("failed to configure VF GUID for vfio-pci device: %v", err)
+		}
+	}
+
+	result := &current.Result{}
+	result.Interfaces = []*current.Interface{{
+		Name:    args.IfName,
+		Sandbox: netns.Path(),
+	}}
+
+	// Cache NetConf for CmdDel (minimal config for vfio-pci mode)
+	if err = utils.SaveNetConf(args.ContainerID, config.DefaultCNIDir, args.IfName, netConf); err != nil {
+		return fmt.Errorf("error saving NetConf %q", err)
+	}
+
+	return types.PrintResult(result, netConf.CNIVersion)
+}
+
+// setupIPAMAndResult handles IPAM configuration and creates the result
+func setupIPAMAndResult(args *skel.CmdArgs, netConf *localtypes.NetConf, netns ns.NetNS) (*current.Result, func(error), error) {
+	result := &current.Result{}
+	result.Interfaces = []*current.Interface{{
+		Name:    args.IfName,
+		Sandbox: netns.Path(),
+	}}
+
+	// Default cleanup function (no-op)
+	cleanup := func(error) {}
+
+	if netConf.IPAM.Type != "" {
+		newResult, err := runIPAMPlugin(args.StdinData, netConf)
+		if err != nil {
+			return nil, cleanup, err
+		}
+
+		// Return cleanup function for IPAM
+		cleanup = func(retErr error) {
+			if retErr != nil {
+				_ = ipam.ExecDel(netConf.IPAM.Type, args.StdinData)
+			}
+		}
+
+		newResult.Interfaces = result.Interfaces
+
+		for _, ipc := range newResult.IPs {
+			// only a single interface is handled by ib-sriov-cni, point ip IPConfig.Interface to it.
+			ipc.Interface = current.Int(0)
+		}
+
+		err = netns.Do(func(_ ns.NetNS) error {
+			return ipam.ConfigureIface(args.IfName, newResult)
+		})
+		if err != nil {
+			return nil, cleanup, err
+		}
+
+		result = newResult
+	}
+
+	return result, cleanup, nil
+}
+
 func cmdAdd(args *skel.CmdArgs) (retErr error) {
 	netConf, netns, err := getNetConfNetns(args)
 	if err != nil {
 		return err
 	}
 	defer netns.Close()
+
+	// If device is bound to vfio-pci, handle VF GUID setting if needed, then skip SR-IOV configuration
+	if netConf.VfioPciMode {
+		return handleVfioPciMode(args, netConf, netns)
+	}
 
 	sm := sriov.NewSriovManager()
 
@@ -237,12 +355,15 @@ func cmdAdd(args *skel.CmdArgs) (retErr error) {
 	}
 	defer func() {
 		if retErr != nil {
-			nsErr := netns.Do(func(_ ns.NetNS) error {
-				_, innerErr := netlink.LinkByName(args.IfName)
-				return innerErr
-			})
-			if nsErr == nil {
-				_ = sm.ReleaseVF(netConf, args.IfName, args.ContainerID, netns)
+			// Skip cleanup for VFIO devices as they don't have network interfaces to manage
+			if !netConf.VfioPciMode {
+				nsErr := netns.Do(func(_ ns.NetNS) error {
+					_, innerErr := netlink.LinkByName(args.IfName)
+					return innerErr
+				})
+				if nsErr == nil {
+					_ = sm.ReleaseVF(netConf, args.IfName, args.ContainerID, netns)
+				}
 			}
 			if netConf.RdmaIso {
 				_ = utils.MoveRdmaDevFromNs(netConf.RdmaNetState.ContainerRdmaDevName, netns)
@@ -250,41 +371,13 @@ func cmdAdd(args *skel.CmdArgs) (retErr error) {
 		}
 	}()
 
-	result := &current.Result{}
-	result.Interfaces = []*current.Interface{{
-		Name:    args.IfName,
-		Sandbox: netns.Path(),
-	}}
-
-	if netConf.IPAM.Type != "" {
-		var newResult *current.Result
-		newResult, err = runIPAMPlugin(args.StdinData, netConf)
-		if err != nil {
-			return err
-		}
-		// If runIPAMPlugin failed, than ExecDel was called. Defer if no error
-		defer func() {
-			if retErr != nil {
-				_ = ipam.ExecDel(netConf.IPAM.Type, args.StdinData)
-			}
-		}()
-
-		newResult.Interfaces = result.Interfaces
-
-		for _, ipc := range newResult.IPs {
-			// only a single interface is handled by ib-sriov-cni, point ip IPConfig.Interface to it.
-			ipc.Interface = current.Int(0)
-		}
-
-		err = netns.Do(func(_ ns.NetNS) error {
-			return ipam.ConfigureIface(args.IfName, newResult)
-		})
-		if err != nil {
-			return err
-		}
-
-		result = newResult
+	result, ipamCleanup, err := setupIPAMAndResult(args, netConf, netns)
+	if err != nil {
+		return err
 	}
+	defer func() {
+		ipamCleanup(retErr)
+	}()
 
 	// Cache NetConf for CmdDel
 	if err = utils.SaveNetConf(args.ContainerID, config.DefaultCNIDir, args.IfName, netConf); err != nil {
@@ -292,6 +385,16 @@ func cmdAdd(args *skel.CmdArgs) (retErr error) {
 	}
 
 	return types.PrintResult(result, netConf.CNIVersion)
+}
+
+func handleIPAMCleanup(netConf *localtypes.NetConf, stdinData []byte) error {
+	if netConf.IPAM.Type == "" {
+		return nil
+	}
+	if netConf.IPAM.Type == ipamDHCP {
+		return fmt.Errorf("ipam type dhcp is not supported")
+	}
+	return ipam.ExecDel(netConf.IPAM.Type, stdinData)
 }
 
 func cmdDel(args *skel.CmdArgs) (retErr error) {
@@ -317,16 +420,16 @@ func cmdDel(args *skel.CmdArgs) (retErr error) {
 		}()
 	}
 
+	// If device was in vfio-pci mode, skip all SR-IOV and IPAM cleanup
+	if netConf.VfioPciMode {
+		return nil
+	}
+
 	sm := sriov.NewSriovManager()
 
-	if netConf.IPAM.Type != "" {
-		if netConf.IPAM.Type == ipamDHCP {
-			return fmt.Errorf("ipam type dhcp is not supported")
-		}
-		err = ipam.ExecDel(netConf.IPAM.Type, args.StdinData)
-		if err != nil {
-			return err
-		}
+	err = handleIPAMCleanup(netConf, args.StdinData)
+	if err != nil {
+		return err
 	}
 
 	netns, err := ns.GetNS(args.Netns)

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -60,6 +60,27 @@ func LoadDeviceInfo(netConf *types.NetConf) error {
 	return nil
 }
 
+// LoadDeviceInfoVfioVF loads device information for VFIO VF devices (no network interface)
+func LoadDeviceInfoVfioVF(netConf *types.NetConf) error {
+	// DeviceID takes precedence; if we are given a VF pciaddr then work from there
+	if netConf.DeviceID != "" {
+		// Get rest of the VF information
+		pfName, vfID, err := getVfInfo(netConf.DeviceID)
+		if err != nil {
+			return fmt.Errorf("load config: failed to get VF information: %q", err)
+		}
+		netConf.VFID = vfID
+		netConf.Master = pfName
+
+		// For VFIO VF, we don't have network interface, so set HostIFNames to empty
+		netConf.HostIFNames = ""
+	} else {
+		return fmt.Errorf("load config: vf pci addr is required")
+	}
+
+	return nil
+}
+
 func getVfInfo(vfPci string) (string, int, error) {
 	var vfID int
 

--- a/pkg/sriov/sriov.go
+++ b/pkg/sriov/sriov.go
@@ -126,6 +126,9 @@ func (s *sriovManager) SetupVF(conf *types.NetConf, podifName, cid string, netns
 		return fmt.Errorf("failed to get VF %s name after rebind with error, %q", conf.DeviceID, err)
 	}
 
+	// Update HostIFNames to the current actual interface name for correct restoration during delete
+	conf.HostIFNames = linkName
+
 	linkObj, err := s.nLink.LinkByName(linkName)
 	if err != nil {
 		return fmt.Errorf("error getting VF netdevice with name %s", linkName)
@@ -184,18 +187,28 @@ func (s *sriovManager) SetupVF(conf *types.NetConf, podifName, cid string, netns
 
 // ReleaseVF reset a VF from Pod netns and return it to init netns
 func (s *sriovManager) ReleaseVF(conf *types.NetConf, podifName, cid string, netns ns.NetNS) error {
+	// For VFIO devices, skip VF release operations since there's no network interface to manage
+	if conf.VfioPciMode {
+		return nil
+	}
+
 	initns, err := ns.GetCurrentNS()
 	if err != nil {
 		return fmt.Errorf("failed to get init netns: %v", err)
 	}
 
-	if len(conf.ContIFNames) < 1 && len(conf.ContIFNames) != len(conf.HostIFNames) {
-		return fmt.Errorf(
-			"number of interface names mismatch ContIFNames: %d HostIFNames: %d",
-			len(conf.ContIFNames), len(conf.HostIFNames))
+	// For cases where HostIFNames is missing from cached config, we'll use rebind approach
+	// After moving the interface back to host namespace, rebind the VF to get correct name
+	useRebindForNaming := conf.HostIFNames == ""
+
+	// Validate that we have container interface name to work with
+	if conf.ContIFNames == "" {
+		// Silently skip cleanup if container interface name is missing
+		// This can happen with corrupted or incomplete cached configs
+		return nil
 	}
 
-	return netns.Do(func(_ ns.NetNS) error {
+	err = netns.Do(func(_ ns.NetNS) error {
 		// get VF device
 		linkObj, err := s.nLink.LinkByName(podifName)
 		if err != nil {
@@ -207,19 +220,112 @@ func (s *sriovManager) ReleaseVF(conf *types.NetConf, podifName, cid string, net
 			return fmt.Errorf("failed to set link %s down: %q", podifName, err)
 		}
 
-		// rename VF device
-		err = s.nLink.LinkSetName(linkObj, conf.HostIFNames)
-		if err != nil {
-			return fmt.Errorf("failed to rename link %s to host name %s: %q", podifName, conf.HostIFNames, err)
+		// Only try to rename if we have a valid host interface name
+		if !useRebindForNaming && conf.HostIFNames != "" {
+			// rename VF device - if this fails, continue anyway as the main goal is to move the interface back
+			_ = s.nLink.LinkSetName(linkObj, conf.HostIFNames)
+			// Silently ignore rename errors - the interface will still be moved back to host namespace
+			// This can happen if there's a naming conflict or if the generated name is invalid
+			// The main goal is to move the interface back, renaming is secondary
 		}
 
 		// move VF device to init netns
 		if err = s.nLink.LinkSetNsFd(linkObj, int(initns.Fd())); err != nil {
-			return fmt.Errorf("failed to move interface %s to init netns: %v", conf.HostIFNames, err)
+			return fmt.Errorf("failed to move interface %s to init netns: %v", podifName, err)
 		}
 
 		return nil
 	})
+
+	// If we skipped renaming due to missing host interface name, rebind the VF to get correct name
+	if err == nil && useRebindForNaming {
+		// Rebind the VF to ensure it gets the correct interface name in host namespace
+		_ = s.utils.RebindVf(conf.Master, conf.DeviceID)
+		// Don't fail the entire operation if rebind fails - the interface is already back in host namespace
+		// This is just for getting the correct name, which is not critical for deletion success
+	}
+
+	return err
+}
+
+// setVFLinkState sets the VF link state
+func (s *sriovManager) setVFLinkState(conf *types.NetConf, pfLink netlink.Link) error {
+	if conf.LinkState == "" {
+		return nil
+	}
+
+	var state uint32
+	switch conf.LinkState {
+	case "auto":
+		state = netlink.VF_LINK_STATE_AUTO
+	case "enable":
+		state = netlink.VF_LINK_STATE_ENABLE
+	case "disable":
+		state = netlink.VF_LINK_STATE_DISABLE
+	default:
+		// the value should have been validated earlier, return error if we somehow got here
+		return fmt.Errorf("unknown link state %s when setting it for vf %d", conf.LinkState, conf.VFID)
+	}
+
+	if err := s.nLink.LinkSetVfState(pfLink, conf.VFID, state); err != nil {
+		return fmt.Errorf("failed to set vf %d link state to %d: %v", conf.VFID, state, err)
+	}
+
+	return nil
+}
+
+// handleVFGuidConfiguration handles VF GUID setting and validation
+func (s *sriovManager) handleVFGuidConfiguration(conf *types.NetConf, pfLink netlink.Link) error {
+	if conf.GUID != "" {
+		return s.setVFGuid(conf, pfLink)
+	}
+	return s.validateVFGuid(conf)
+}
+
+// setVFGuid sets the VF GUID
+func (s *sriovManager) setVFGuid(conf *types.NetConf, pfLink netlink.Link) error {
+	if !utils.IsValidGUID(conf.GUID) {
+		return fmt.Errorf("invalid guid %s", conf.GUID)
+	}
+
+	// For VFIO VF devices, we don't have a network interface, so skip VF link operations
+	if conf.VfioPciMode && conf.HostIFNames == "" {
+		// VFIO VF: Just set the GUID directly via PF, no VF link to query
+		return s.setVfGUID(conf, pfLink, conf.GUID)
+	}
+
+	// Normal VF (not VFIO): save current link guid and set new one
+	vfLink, err := s.nLink.LinkByName(conf.HostIFNames)
+	if err != nil {
+		return fmt.Errorf("failed to lookup vf %q: %v", conf.HostIFNames, err)
+	}
+
+	conf.HostIFGUID = vfLink.Attrs().HardwareAddr.String()[36:]
+
+	// Set link guid
+	return s.setVfGUID(conf, pfLink, conf.GUID)
+}
+
+// validateVFGuid validates that the VF has a valid GUID
+func (s *sriovManager) validateVFGuid(conf *types.NetConf) error {
+	// For VFIO VF devices, skip GUID validation since we can't access the VF interface
+	if conf.VfioPciMode && conf.HostIFNames == "" {
+		// VFIO VF without GUID specified: nothing to do, just return success
+		return nil
+	}
+
+	// Normal VF: Verify VF have valid GUID.
+	vfLink, err := s.nLink.LinkByName(conf.HostIFNames)
+	if err != nil {
+		return fmt.Errorf("failed to lookup vf %q: %v", conf.HostIFNames, err)
+	}
+
+	guid := utils.GetGUIDFromHwAddr(vfLink.Attrs().HardwareAddr)
+	if guid == "" || utils.IsAllZeroGUID(guid) || utils.IsAllOnesGUID(guid) {
+		return fmt.Errorf("VF %s GUID is not valid", conf.HostIFNames)
+	}
+
+	return nil
 }
 
 // ApplyVFConfig configure a VF with parameters given in NetConf
@@ -230,52 +336,18 @@ func (s *sriovManager) ApplyVFConfig(conf *types.NetConf) error {
 	}
 
 	// Set link state
-	if conf.LinkState != "" {
-		var state uint32
-		switch conf.LinkState {
-		case "auto":
-			state = netlink.VF_LINK_STATE_AUTO
-		case "enable":
-			state = netlink.VF_LINK_STATE_ENABLE
-		case "disable":
-			state = netlink.VF_LINK_STATE_DISABLE
-		default:
-			// the value should have been validated earlier, return error if we somehow got here
-			return fmt.Errorf("unknown link state %s when setting it for vf %d: %v", conf.LinkState, conf.VFID, err)
-		}
-		if err = s.nLink.LinkSetVfState(pfLink, conf.VFID, state); err != nil {
-			return fmt.Errorf("failed to set vf %d link state to %d: %v", conf.VFID, state, err)
-		}
+	if err := s.setVFLinkState(conf, pfLink); err != nil {
+		return err
 	}
 
-	// Set link guid
-	if conf.GUID != "" {
-		if !utils.IsValidGUID(conf.GUID) {
-			return fmt.Errorf("invalid guid %s", conf.GUID)
-		}
-		// save link guid
-		vfLink, err := s.nLink.LinkByName(conf.HostIFNames)
-		if err != nil {
-			return fmt.Errorf("failed to lookup vf %q: %v", conf.HostIFNames, err)
-		}
+	// Handle VF GUID configuration
+	if err := s.handleVFGuidConfiguration(conf, pfLink); err != nil {
+		return err
+	}
 
-		conf.HostIFGUID = vfLink.Attrs().HardwareAddr.String()[36:]
-
-		// Set link guid
-		if err := s.setVfGUID(conf, pfLink, conf.GUID); err != nil {
-			return err
-		}
-	} else {
-		// Verify VF have valid GUID.
-		vfLink, err := s.nLink.LinkByName(conf.HostIFNames)
-		if err != nil {
-			return fmt.Errorf("failed to lookup vf %q: %v", conf.HostIFNames, err)
-		}
-
-		guid := utils.GetGUIDFromHwAddr(vfLink.Attrs().HardwareAddr)
-		if guid == "" || utils.IsAllZeroGUID(guid) || utils.IsAllOnesGUID(guid) {
-			return fmt.Errorf("VF %s GUID is not valid", conf.HostIFNames)
-		}
+	// If it's VF VFIO type, return success after setting VF GUID
+	if conf.VfioPciMode {
+		return nil
 	}
 
 	return nil
@@ -309,9 +381,34 @@ func (s *sriovManager) restoreVFName(conf *types.NetConf) error {
 
 // ResetVFConfig reset a VF with default values
 func (s *sriovManager) ResetVFConfig(conf *types.NetConf) error {
-	pfLink, err := s.nLink.LinkByName(conf.Master)
+	// If Master (PF name) is missing from cached config, try to derive it from device ID
+	masterName := conf.Master
+	if masterName == "" && conf.DeviceID != "" {
+		// Try to get PF name from VF PCI address
+		pfName, err := utils.GetPfName(conf.DeviceID)
+		if err != nil {
+			// If we can't determine the PF name, skip VF reset silently
+			return nil
+		}
+		masterName = pfName
+
+		// Also get VF ID if it's missing
+		if conf.VFID == 0 { // Assuming 0 means unset, though VF 0 is valid
+			vfID, err := utils.GetVfid(conf.DeviceID, pfName)
+			if err == nil {
+				conf.VFID = vfID
+			}
+		}
+	}
+
+	// If we still don't have a master name, skip reset
+	if masterName == "" {
+		return nil
+	}
+
+	pfLink, err := s.nLink.LinkByName(masterName)
 	if err != nil {
-		return fmt.Errorf("failed to lookup master %q: %v", conf.Master, err)
+		return fmt.Errorf("failed to lookup master %q: %v", masterName, err)
 	}
 
 	// Reset link state to `auto`
@@ -336,8 +433,11 @@ func (s *sriovManager) ResetVFConfig(conf *types.NetConf) error {
 			return err
 		}
 		// setVfGUID cause VF to rebind, which change its name. Lets restore it.
+		// For VFIO devices, skip VF name restoration since no rebind occurs
 		// Once setVfGUID wouldn't do rebind to apply GUID this function should be removed
-		return s.restoreVFName(conf)
+		if !conf.VfioPciMode {
+			return s.restoreVFName(conf)
+		}
 	}
 
 	return nil
@@ -356,10 +456,14 @@ func (s *sriovManager) setVfGUID(conf *types.NetConf, pfLink netlink.Link, guidA
 	if err != nil {
 		return fmt.Errorf("failed to add port guid %s: %v", guid, err)
 	}
-	// unbind vf then bind it to apply the guid
-	err = s.utils.RebindVf(conf.Master, conf.DeviceID)
-	if err != nil {
-		return err
+	// For VFIO devices, skip rebind as the device is bound to vfio-pci driver
+	// and doesn't have a network interface that can be unbound/rebound
+	if !conf.VfioPciMode {
+		// unbind vf then bind it to apply the guid
+		err = s.utils.RebindVf(conf.Master, conf.DeviceID)
+		if err != nil {
+			return err
+		}
 	}
 	return nil
 }

--- a/pkg/sriov/sriov_test.go
+++ b/pkg/sriov/sriov_test.go
@@ -293,6 +293,28 @@ var _ = Describe("Sriov", func() {
 			Expect(err.Error()).To(Equal("mocked failed"))
 			Expect(netconf.HostIFGUID).To(Equal(hostGUID))
 		})
+		It("ApplyVFConfig with valid GUID and VfioPciMode VF (no network interface) - should return success after setting GUID", func() {
+			mockedNetLinkManger := &mocks.NetlinkManager{}
+			mockedPciUtils := &mocks.PciUtils{}
+
+			fakeLink := &FakeLink{netlink.LinkAttrs{}}
+			netconf.GUID = "01:23:45:67:89:ab:cd:ef"
+			netconf.VfioPciMode = true
+			netconf.HostIFNames = "" // VFIO VF has no network interface
+
+			// Only PF link is needed for VFIO VF
+			mockedNetLinkManger.On("LinkByName", netconf.Master).Return(fakeLink, nil)
+			mockedNetLinkManger.On("LinkSetVfNodeGUID", fakeLink, mock.AnythingOfType("int"), mock.Anything).Return(nil)
+			mockedNetLinkManger.On("LinkSetVfPortGUID", fakeLink, mock.AnythingOfType("int"), mock.Anything).Return(nil)
+
+			mockedPciUtils.On("RebindVf", mock.AnythingOfType("string"), mock.AnythingOfType("string")).Return(nil)
+
+			sm := sriovManager{nLink: mockedNetLinkManger, utils: mockedPciUtils}
+			err := sm.ApplyVFConfig(netconf)
+			Expect(err).NotTo(HaveOccurred())
+			// For VFIO VF, HostIFGUID should remain empty since there's no VF interface to query
+			Expect(netconf.HostIFGUID).To(Equal(""))
+		})
 	})
 	Context("Checking SetupVF function", func() {
 		var (
@@ -472,6 +494,7 @@ var _ = Describe("Sriov", func() {
 			mocked.On("LinkByName", mock.AnythingOfType("string")).Return(fakeLink, nil)
 			mocked.On("LinkSetDown", fakeLink).Return(nil)
 			mocked.On("LinkSetName", fakeLink, mock.Anything).Return(errors.New("failed"))
+			mocked.On("LinkSetNsFd", fakeLink, mock.AnythingOfType("int")).Return(errors.New("failed to move"))
 			sm := sriovManager{nLink: mocked}
 			err := sm.ReleaseVF(netconf, podifName, contID, targetNetNS)
 			Expect(err).To(HaveOccurred())

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -30,6 +30,7 @@ type IbSriovNetConf struct {
 	LinkState           string `json:"link_state,omitempty"` // auto|enable|disable
 	RdmaIso             bool   `json:"rdmaIsolation,omitempty"`
 	IBKubernetesEnabled bool   `json:"ibKubernetesEnabled,omitempty"`
+	VfioPciMode         bool   `json:"vfioPciMode,omitempty"` // Skip SR-IOV network setup, default false
 	RdmaNetState        rdmatypes.RdmaNetState
 	RuntimeConfig       RuntimeConf `json:"runtimeConfig,omitempty"`
 	Args                struct {

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -244,3 +244,38 @@ func IsAllZeroGUID(guid string) bool {
 func IsAllOnesGUID(guid string) bool {
 	return guid == "ff:ff:ff:ff:ff:ff:ff:ff" || guid == "FF:FF:FF:FF:FF:FF:FF:FF"
 }
+
+// IsVfioPciDevice checks if a PCI device is bound to vfio-pci driver
+func IsVfioPciDevice(pciAddr string) (bool, error) {
+	driverPath := filepath.Join(SysBusPci, pciAddr, "driver")
+
+	// Check if driver symlink exists
+	linkTarget, err := os.Readlink(driverPath)
+	if err != nil {
+		// If readlink fails, the device might not be bound to any driver
+		return false, nil
+	}
+
+	// Check if the driver is vfio-pci
+	driverName := filepath.Base(linkTarget)
+	return driverName == "vfio-pci", nil
+}
+
+// IsVirtualFunction checks if a PCI device is a VF by checking for physfn symlink
+func IsVirtualFunction(pciAddr string) (bool, error) {
+	physfnPath := filepath.Join(SysBusPci, pciAddr, "physfn")
+
+	// Check if physfn symlink exists
+	_, err := os.Lstat(physfnPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			// physfn doesn't exist, so this is not a VF (likely a PF)
+			return false, nil
+		}
+		// Other error occurred
+		return false, err
+	}
+
+	// physfn exists, so this is a VF
+	return true, nil
+}

--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -81,4 +81,24 @@ var _ = Describe("Utils", func() {
 			Expect(guid).To(Equal(""))
 		})
 	})
+	Context("Checking IsVirtualFunction function", func() {
+		It("Assuming VF device (has physfn)", func() {
+			// This test assumes 0000:af:06.0 is a VF with physfn symlink
+			result, err := IsVirtualFunction("0000:af:06.0")
+			Expect(err).NotTo(HaveOccurred(), "Should not return error for valid PCI address")
+			Expect(result).To(Equal(true), "VF device should return true")
+		})
+		It("Assuming PF device (no physfn)", func() {
+			// This test assumes 0000:af:00.0 is a PF without physfn symlink
+			result, err := IsVirtualFunction("0000:af:00.0")
+			Expect(err).NotTo(HaveOccurred(), "Should not return error for valid PCI address")
+			Expect(result).To(Equal(false), "PF device should return false")
+		})
+		It("Assuming non-existing device", func() {
+			// This should return false and no error for non-existing device
+			result, err := IsVirtualFunction("0000:ff:ff.f")
+			Expect(err).NotTo(HaveOccurred(), "Should not return error for non-existing device")
+			Expect(result).To(Equal(false), "Non-existing device should return false")
+		})
+	})
 })


### PR DESCRIPTION
Add both PF and VF VFIO mode support, which is needed by kubevirt support.