### PR TITLE
shellcheck: fix on MacOS; bump to 0.11.0; check all scripts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -120,7 +120,7 @@ hadolint: $(HADOLINT_TOOL); $(info  running hadolint...) ## Run hadolint
 
 .PHONY: shellcheck
 shellcheck: $(SHELLCHECK_TOOL); $(info  running shellcheck...) ## Run shellcheck
-	$Q $(SHELLCHECK_TOOL) images/entrypoint.sh
+	$Q $(SHELLCHECK_TOOL) images/*.sh
 
 # Container image
 .PHONY: image

--- a/Makefile
+++ b/Makefile
@@ -78,17 +78,13 @@ $(HADOLINT_TOOL): | $(BINDIR) ; $(info  installing hadolint...)
 	$(call wget-install-tool,$(HADOLINT_TOOL),"https://github.com/hadolint/hadolint/releases/download/v2.12.1-beta/hadolint-Linux-x86_64")
 
 SHELLCHECK_TOOL = $(BINDIR)/shellcheck
+SHELLCHECK_VERSION := v0.11.0
 SHELLCHECK_OS := $(shell uname -s | tr A-Z a-z)
 SHELLCHECK_ARCH := $(shell uname -m)
-ifeq ($(SHELLCHECK_OS),darwin)
-	# macOS only has x86_64 binaries available, use them for all architectures
-	SHELLCHECK_ARCH := x86_64
-else
-	ifeq ($(SHELLCHECK_ARCH),arm64)
-		SHELLCHECK_ARCH := aarch64
-	endif
+ifeq ($(SHELLCHECK_ARCH),arm64)
+	SHELLCHECK_ARCH := aarch64
 endif
-SHELLCHECK_URL := https://github.com/koalaman/shellcheck/releases/download/v0.9.0/shellcheck-v0.9.0.$(SHELLCHECK_OS).$(SHELLCHECK_ARCH).tar.xz
+SHELLCHECK_URL := https://github.com/koalaman/shellcheck/releases/download/$(SHELLCHECK_VERSION)/shellcheck-$(SHELLCHECK_VERSION).$(SHELLCHECK_OS).$(SHELLCHECK_ARCH).tar.xz
 $(SHELLCHECK_TOOL): | $(BASE) ; $(info  installing shellcheck...)
 	$(call install-shellcheck,$(BINDIR),$(SHELLCHECK_URL))
 

--- a/Makefile
+++ b/Makefile
@@ -78,8 +78,19 @@ $(HADOLINT_TOOL): | $(BINDIR) ; $(info  installing hadolint...)
 	$(call wget-install-tool,$(HADOLINT_TOOL),"https://github.com/hadolint/hadolint/releases/download/v2.12.1-beta/hadolint-Linux-x86_64")
 
 SHELLCHECK_TOOL = $(BINDIR)/shellcheck
+SHELLCHECK_OS := $(shell uname -s | tr A-Z a-z)
+SHELLCHECK_ARCH := $(shell uname -m)
+ifeq ($(SHELLCHECK_OS),darwin)
+	# macOS only has x86_64 binaries available, use them for all architectures
+	SHELLCHECK_ARCH := x86_64
+else
+	ifeq ($(SHELLCHECK_ARCH),arm64)
+		SHELLCHECK_ARCH := aarch64
+	endif
+endif
+SHELLCHECK_URL := https://github.com/koalaman/shellcheck/releases/download/v0.9.0/shellcheck-v0.9.0.$(SHELLCHECK_OS).$(SHELLCHECK_ARCH).tar.xz
 $(SHELLCHECK_TOOL): | $(BASE) ; $(info  installing shellcheck...)
-	$(call install-shellcheck,$(BINDIR),"https://github.com/koalaman/shellcheck/releases/download/v0.9.0/shellcheck-v0.9.0.linux.x86_64.tar.xz")
+	$(call install-shellcheck,$(BINDIR),$(SHELLCHECK_URL))
 
 # Tests
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved ShellCheck installation to automatically detect platform and architecture, with normalized architecture naming and a computed download URL for reliable cross-platform support.
  * Replaced the single-file check with broader shell script validation across the build pipeline so all shell scripts are linted.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->