### PR TITLE
Bump ib-sriov-cni to Go 1.26

### DIFF
--- a/.github/workflows/buildtest.yaml
+++ b/.github/workflows/buildtest.yaml
@@ -9,7 +9,7 @@ jobs:
     name: build
     strategy:
       matrix:
-        go-version: [1.25.x]
+        go-version: [1.26.x]
         os: [ubuntu-24.04]
         goos: [linux]
         goarch: [amd64]
@@ -35,7 +35,7 @@ jobs:
       - name: set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: 1.25.x
+          go-version: 1.26.x
       - name: check out code into the Go module directory
         uses: actions/checkout@v7
       - name: run unit-test image test
@@ -62,7 +62,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: 1.25.x
+          go-version: 1.26.x
       - name: Check out code into the Go module directory
         uses: actions/checkout@v7
       - name: Go test with coverage

--- a/.github/workflows/static-scan.yaml
+++ b/.github/workflows/static-scan.yaml
@@ -8,7 +8,7 @@ jobs:
       - name: set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: 1.25.x
+          go-version: 1.26.x
       - name: checkout PR
         uses: actions/checkout@v7
       - name: run make lint

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/k8snetworkplumbingwg/ib-sriov-cni
 
-go 1.25.3
+go 1.26
 
 require (
 	github.com/containernetworking/cni v1.3.0


### PR DESCRIPTION
## Summary

Bumps the ib-sriov-cni project from Go 1.25.3 to Go 1.26. This updates the Go directive in `go.mod` and all CI workflow configurations to use the new Go version. A `.coderabbit.yaml` configuration file is also added for automated code review.

## Key Changes

- **`go.mod`**: Updated the `go` directive from `1.25.3` to `1.26`
- **`.github/workflows/buildtest.yaml`**: Updated Go version from `1.25.x` to `1.26.x` across all jobs (build matrix, unit-test image, coverage)
- **`.github/workflows/static-scan.yaml`**: Updated Go version from `1.25.x` to `1.26.x` for the lint job
- **`.coderabbit.yaml`**: Added CodeRabbit configuration with project-specific review instructions covering:
  - Go best practices and security guidelines tailored to InfiniBand SR-IOV CNI
  - Path-specific review instructions for CNI plugin code, SR-IOV VF management, config parsing, utilities, tests, Dockerfiles, manifests, CI/CD, and dependencies
  - Enabled security scanning tools (gitleaks, semgrep, checkov, hadolint, trivy, osvScanner, actionlint, ast-grep)

## Notable Decisions

- The existing `golangci-lint` version (v2.7.2) was left unchanged as it is already at the latest version and compatible with Go 1.26
- No Kubernetes package or code-generator updates were needed since the project doesn't depend on them
- No Dockerfile changes were required as they don't hardcode the Go version directly