### PR TITLE
fix: validate cache path components and deviceID format

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"path/filepath"
+	"regexp"
 	"strings"
 
 	"github.com/containernetworking/cni/pkg/skel"
@@ -13,6 +14,8 @@ import (
 )
 
 var (
+	// pciAddrRegex validates PCI Bus-Device-Function address format (device is 5 bits: 00-1f)
+	pciAddrRegex = regexp.MustCompile(`^[0-9a-fA-F]{4}:[0-9a-fA-F]{2}:[01][0-9a-fA-F]\.[0-7]$`)
 	// DefaultCNIDir used for caching NetConf
 	DefaultCNIDir = "/var/lib/cni/ib-sriov"
 	// CniFileLockDir point to the CNI's lockfile
@@ -26,6 +29,13 @@ func LoadConf(bytes []byte) (*types.NetConf, error) {
 	n := &types.NetConf{}
 	if err := json.Unmarshal(bytes, n); err != nil {
 		return nil, fmt.Errorf("failed to load netconf: %v", err)
+	}
+
+	if n.DeviceID != "" {
+		if !pciAddrRegex.MatchString(n.DeviceID) {
+			return nil, fmt.Errorf("invalid deviceID %q: not a valid PCI address (expected DDDD:DD:DD.D)", n.DeviceID)
+		}
+		n.DeviceID = strings.ToLower(n.DeviceID)
 	}
 
 	// validate that link state is one of supported values
@@ -84,7 +94,12 @@ func getVfInfo(vfPci string) (string, int, error) {
 
 // LoadConfFromCache retrieves cached NetConf returns it along with a handle for removal
 func LoadConfFromCache(args *skel.CmdArgs) (*types.NetConf, string, error) {
-	netConf := &types.NetConf{}
+	if err := utils.ValidatePathComponents(
+		utils.PathComponent{Name: "container ID", Value: args.ContainerID},
+		utils.PathComponent{Name: "interface name", Value: args.IfName},
+	); err != nil {
+		return nil, "", err
+	}
 
 	s := []string{args.ContainerID, args.IfName}
 	cRef := strings.Join(s, "-")
@@ -95,8 +110,9 @@ func LoadConfFromCache(args *skel.CmdArgs) (*types.NetConf, string, error) {
 		return nil, "", fmt.Errorf("error reading cached NetConf in %s with name %s", DefaultCNIDir, cRef)
 	}
 
-	if err = json.Unmarshal(netConfBytes, netConf); err != nil {
-		return nil, "", fmt.Errorf("failed to parse NetConf: %q", err)
+	netConf, err := LoadConf(netConfBytes)
+	if err != nil {
+		return nil, "", fmt.Errorf("failed to validate cached NetConf: %w", err)
 	}
 
 	return netConf, cRefPath, nil

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -165,9 +165,36 @@ func GetVFLinkNamesFromVFID(pfName string, vfID int) ([]string, error) {
 	return names, nil
 }
 
-// SaveNetConf takes in container ID, data dir and Pod interface name as string and a json encoded struct Conf
-// and save this Conf in data dir
+// PathComponent represents a named value to validate for path separators.
+type PathComponent struct {
+	Name  string
+	Value string
+}
+
+// ValidatePathComponents checks that none of the given components contain
+// path separator characters (/ or \). Returns an error identifying the
+// first offending component, or nil if all are clean.
+func ValidatePathComponents(components ...PathComponent) error {
+	for _, c := range components {
+		if strings.ContainsAny(c.Value, "/\\") {
+			return fmt.Errorf("invalid %s %q: contains path separator", c.Name, c.Value)
+		}
+	}
+	return nil
+}
+
+// SaveNetConf validates and saves the container network configuration.
+// It takes a container ID, data dir, pod interface name, and a Conf struct,
+// and persists the configuration in the data dir. It rejects container IDs
+// and interface names containing path separators.
 func SaveNetConf(cid, dataDir, podIfName string, conf interface{}) error {
+	if err := ValidatePathComponents(
+		PathComponent{Name: "container ID", Value: cid},
+		PathComponent{Name: "interface name", Value: podIfName},
+	); err != nil {
+		return err
+	}
+
 	netConfBytes, err := json.Marshal(conf)
 	if err != nil {
 		return fmt.Errorf("error serializing delegate netconf: %v", err)

--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -107,6 +107,50 @@ var _ = Describe("Utils", func() {
 			Expect(result).To(Equal(false), "Non-existing device should return false")
 		})
 	})
+	Context("Checking ValidatePathComponents function", func() {
+		It("Should accept clean component values", func() {
+			err := ValidatePathComponents(
+				PathComponent{Name: "container ID", Value: "abc123"},
+				PathComponent{Name: "interface name", Value: "eth0"},
+			)
+			Expect(err).NotTo(HaveOccurred())
+		})
+		It("Should reject component with forward slash", func() {
+			err := ValidatePathComponents(
+				PathComponent{Name: "container ID", Value: "abc/def"},
+			)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("container ID"))
+			Expect(err.Error()).To(ContainSubstring("path separator"))
+		})
+		It("Should reject component with backslash", func() {
+			err := ValidatePathComponents(
+				PathComponent{Name: "interface name", Value: `eth\0`},
+			)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("interface name"))
+		})
+		It("Should reject component with path traversal pattern", func() {
+			err := ValidatePathComponents(
+				PathComponent{Name: "container ID", Value: "../../tmp"},
+			)
+			Expect(err).To(HaveOccurred())
+		})
+		It("Should reject only the first invalid component", func() {
+			err := ValidatePathComponents(
+				PathComponent{Name: "container ID", Value: "a/b"},
+				PathComponent{Name: "interface name", Value: "c/d"},
+			)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("container ID"))
+		})
+		It("Should accept empty component value", func() {
+			err := ValidatePathComponents(
+				PathComponent{Name: "container ID", Value: ""},
+			)
+			Expect(err).NotTo(HaveOccurred())
+		})
+	})
 	Context("Checking IsVfioPciDevice function", func() {
 		It("Assuming device bound to vfio-pci driver", func() {
 			// Test with VF (0000:af:06.1) that is bound to vfio-pci in the mock


### PR DESCRIPTION
CNI_CONTAINERID and CNI_IFNAME values are used in cache file path construction without input validation. The deviceID field is passed to sysfs path construction without format validation.

Add path separator rejection for container ID and interface name in SaveNetConf and LoadConfFromCache via a shared ValidatePathComponents helper. Add PCI BDF regex validation for deviceID in LoadConf.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added stricter validation for device identifiers to match the expected PCI BDF format, including normalization when valid.
  * Improved cached configuration safety by rejecting invalid container and interface name path components before reading/writing.
  * Cached network configuration validation now reuses the standard configuration loader to surface consistent errors.

* **Tests**
  * Added coverage for path-component validation, including separator, traversal, and multi-component error handling scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->